### PR TITLE
mysql2 compatibility, DB time string formatting, and a README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This method will not propagate normal `DELETES`s to the new table if they happen
 
 TableMigrator supports two APIs for defining migrations. One uses ActiveRecord's `change_table` syntax, and the other uses manually defined SQL snippets. You can create your migration by inheriting from TableMigration and skip some of the setup normally required.
 
-    # using change_table
+Using change_table:
 
     class AddStuffToMyBigTable < TableMigration
 
@@ -57,7 +57,7 @@ TableMigrator supports two APIs for defining migrations. One uses ActiveRecord's
     end
 
 
-    # using raw sql
+Using raw sql:
 
     class AddStuffToMyBigTable < TableMigration
       migrates :users

--- a/lib/table_migrator/base.rb
+++ b/lib/table_migrator/base.rb
@@ -7,7 +7,7 @@ module TableMigrator
     def initialize(table, config = {})
       self.table = table
       
-      defaults = { :dry_run => false, :create_temp_table => true, :delta_column => 'updated_at'}
+      defaults = { :multi_pass => true, :dry_run => false, :create_temp_table => true, :delta_column => 'updated_at'}
       self.config = defaults.merge(config)
     end
 

--- a/lib/table_migrator/copy_engine.rb
+++ b/lib/table_migrator/copy_engine.rb
@@ -158,7 +158,7 @@ module TableMigrator
     def flop_epoch
       epoch = @next_epoch
       @next_epoch = self.next_epoch
-      info "Current Epoch starts at: #{@next_epoch}"
+      info "Current Epoch starts at: #{@next_epoch.to_s(:db)}"
       epoch
     end
 
@@ -187,11 +187,11 @@ module TableMigrator
     end
 
     def full_delta_copy_query(epoch)
-    "#{base_copy_query} WHERE `#{delta_column}` >= '#{epoch}'"
+    "#{base_copy_query} WHERE `#{delta_column}` >= '#{epoch.to_s(:db)}'"
     end
 
     def updated_ids_query(epoch)
-    "SELECT `id` FROM #{table_name} WHERE `#{delta_column}` >= '#{epoch}'"
+    "SELECT `id` FROM #{table_name} WHERE `#{delta_column}` >= '#{epoch.to_s(:db)}'"
     end
 
     def paged_delta_copy_query(ids)

--- a/lib/table_migrator/copy_engine.rb
+++ b/lib/table_migrator/copy_engine.rb
@@ -25,7 +25,7 @@ module TableMigrator
       self.create_new_table if create_temp_table?
 
       # is there any data to copy?
-      if dry_run? or execute("SELECT * FROM `#{table_name}` LIMIT 1").fetch_row
+      if dry_run? or select_all("SELECT * FROM `#{table_name}` LIMIT 1").first
 
         # copy bulk of table data
         self.paged_copy if create_temp_table?


### PR DESCRIPTION
A few simple patches which allowed me to get up and running.
- mysql2 support (while keeping mysql compatibility) since that's popular these days
- times which are stringified in queries were causing "Incorrect datetime value: 'Wed Jan 12 10:53:00 UTC 2011' for column 'updated_at' at row 1: REPLACE INTO ..." perhaps because I have `config.time_zone = 'UTC'`. Using .to_s(:db) formats it correctly.
- a tiny README formatting improvement
